### PR TITLE
WIP: Alter OCaml interpreter interface

### DIFF
--- a/crates/fuzzing/wasm-spec-interpreter/ocaml/interpret.ml
+++ b/crates/fuzzing/wasm-spec-interpreter/ocaml/interpret.ml
@@ -1,22 +1,34 @@
-(* This module exposes an [interpret] function to Rust. It wraps several different calls from the
-WebAssembly specification interpreter in a way that we can access across the FFI boundary. To
-understand this better, see:
- - the OCaml manual documentation re: calling OCaml from C, https://ocaml.org/manual/intfc.html#s%3Ac-advexample
- - the [ocaml-interop] example, https://github.com/tezedge/ocaml-interop/blob/master/testing/rust-caller/ocaml/callable.ml
+(* This module exposes an [interpret] function to Rust. It wraps several
+different calls from the WebAssembly specification interpreter in a way that we
+can access across the FFI boundary. To understand this better, see:
+ - the OCaml manual documentation re: calling OCaml from C,
+ https://ocaml.org/manual/intfc.html#s%3Ac-advexample
+ - the [ocaml-interop] example,
+ https://github.com/tezedge/ocaml-interop/blob/master/testing/rust-caller/ocaml/callable.ml
 *)
 
-(* Here we access the WebAssembly specification interpreter; this must be linked in. *)
-open Wasm
-open Wasm.WasmRef_Isa_m.WasmRef_Isa
-
-(** Enumerate the types of values we pass across the FFI boundary. This must match `Value` in
-`src/lib.rs` *)
+(** Enumerate the types of values we pass across the FFI boundary. This must
+match `Value` in `src/lib.rs` *)
 type ffi_value =
   | I32 of int32
   | I64 of int64
   | F32 of int32
   | F64 of int64
   | V128 of Bytes.t
+
+(** An opaque reference to the instance used by the interpreter. This is
+currently using a garbage type (TODO). *)
+type ffi_instance = int
+
+(** Enumerate the kinds of things the interpreter can export. *)
+type ffi_export =
+  | Memory of Bytes.t
+  | Global of ffi_value
+
+(* Here we access the WebAssembly specification interpreter; this must be linked
+in. *)
+open Wasm
+open Wasm.WasmRef_Isa_m.WasmRef_Isa
 
 (** Helper for converting the FFI values to their spec interpreter type. *)
 let convert_to_wasm (v: ffi_value) : v = match v with
@@ -33,24 +45,20 @@ let convert_from_wasm (v: v) : ffi_value = match v with
 | V_num ((ConstFloat32 n)) -> F32 (F32.to_bits n)
 | V_num ((ConstFloat64 n)) -> F64 (F64.to_bits n)
 | V_vec ((ConstVec128 n)) -> V128 (Bytes.of_string (V128.to_bits n))
-| _ -> failwith "Unknown type"
 
-(** Parse the given WebAssembly module binary into an Ast.module_. At some point in the future this
-should also be able to parse the textual form (TODO). *)
+(** Parse the given WebAssembly module binary into an Ast.module_. At some point
+in the future this should also be able to parse the textual form (TODO). *)
 let parse bytes =
   (* Optionally, use Bytes.unsafe_to_string here to avoid the copy *)
   let bytes_as_str = Bytes.to_string bytes in
   (Decode.decode "default" bytes_as_str)
 
-(** Return true if an export is a function. *)
-let match_exported_func export = match export with
-| Module_export_ext(_,Ext_func n,_) -> true
-| _ -> false
+(** Construct an instance from a sequence of WebAssembly bytes. *)
+let instantiate module_bytes = Ok(42)
 
-(** Extract a function from its export or fail. *)
-let extract_exported_func export = match export with
-| Module_export_ext(_,Ext_func n,_) -> n
-| _ -> failwith ""
+(** Retrieve an export by name from a WebAssembly instance. *)
+let export instance name =
+  print_endline "here"; Error("no export found")
 
 (** Interpret the first exported function and return the result. Use provided
 parameters if they exist, otherwise use default (zeroed) values. *)
@@ -66,7 +74,6 @@ let interpret_exn module_bytes opt_params =
   | (s', (RCrash (Error_exhaustion str))) -> raise (Eval.Exhaustion (Source.no_region, "(Isabelle) call stack exhausted"))
   | (s', (RCrash (Error_invalid str))) -> raise (Eval.Crash (Source.no_region, "(Isabelle) error: " ^ str))
   | (s', (RCrash (Error_invariant str))) -> raise (Eval.Crash (Source.no_region, "(Isabelle) error: " ^ str))
-  (* TODO eventually we should hash the memory state and return the hash *)
   )
 
 let interpret module_bytes opt_params =
@@ -74,4 +81,6 @@ let interpret module_bytes opt_params =
   | _ as e -> Error(Printexc.to_string e)
 
 let () =
+  Callback.register "instantiate" instantiate;
   Callback.register "interpret" interpret;
+  Callback.register "export" export;


### PR DESCRIPTION
In order to properly hash the WebAssembly instance being evaluated in
the spec interpreter, we need to alter the interpreter interface. This
involves adding new types as is done here, e.g., `OCamlInstance`, that
are never truly accessed from the Rust side but only passed around as
opaque handles.

<!--

Please ensure that the following steps are all taken care of before submitting
the PR.

- [ ] This has been discussed in issue #..., or if not, please tell us why
  here.
- [ ] A short description of what this does, why it is needed; if the
  description becomes long, the matter should probably be discussed in an issue
  first.
- [ ] This PR contains test cases, if meaningful.
- [ ] A reviewer from the core maintainer team has been assigned for this PR.
  If you don't know who could review this, please indicate so. The list of
  suggested reviewers on the right can help you.

Please ensure all communication adheres to the [code of
conduct](https://github.com/bytecodealliance/wasmtime/blob/master/CODE_OF_CONDUCT.md).
-->
